### PR TITLE
Changes GET to POST request when getting an access token

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -31,7 +31,7 @@ const validateQuery = [
  * Redirect URI - Zoom App Launch handler
  * The user is redirected to this route when they authorize your app
  */
-router.get('/', session, validateQuery, async (req, res, next) => {
+router.post('/', session, validateQuery, async (req, res, next) => {
     req.session.state = null;
 
     try {


### PR DESCRIPTION
Changes `GET` to `POST` request when getting an access token in `server/routes/auth.js` to fix `400 Bad Request` when adding app.